### PR TITLE
Alternate solution to async image cell reuse issue

### DIFF
--- a/movie-app/Controller/ViewController.swift
+++ b/movie-app/Controller/ViewController.swift
@@ -153,13 +153,6 @@ extension ViewController: UICollectionViewDataSource, UICollectionViewDelegateFl
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "collectionCell", for: indexPath) as! CollectionCell
-        return cell
-    }
-    
-    func collectionView(_ collectionView: UICollectionView, willDisplay cell: UICollectionViewCell, forItemAt indexPath: IndexPath) {
-    
-        guard let cell = cell as? CollectionCell else { return }
-        
         let item = items[indexPath.row]
         cell.title.text = item.title
         
@@ -174,7 +167,7 @@ extension ViewController: UICollectionViewDataSource, UICollectionViewDelegateFl
                     return
                 }
                 DispatchQueue.main.async {
-                    if let cell = collectionView.cellForItem(at: indexPath) as? CollectionCell {
+                    if posterPath == pathString {
                         cell.imageView?.image = image
                     }
                 }
@@ -182,6 +175,7 @@ extension ViewController: UICollectionViewDataSource, UICollectionViewDelegateFl
         } else {
             cell.imageView?.image = UIImage(named: "image.jpg")
         }
+        return cell
     }
     
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {

--- a/movie-app/Controller/ViewController.swift
+++ b/movie-app/Controller/ViewController.swift
@@ -155,6 +155,7 @@ extension ViewController: UICollectionViewDataSource, UICollectionViewDelegateFl
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "collectionCell", for: indexPath) as! CollectionCell
         let item = items[indexPath.row]
         cell.title.text = item.title
+        cell.posterPath = item.posterPath
         
         if let rating = item.voteAverage {
             cell.ratingView?.value = CGFloat(rating)
@@ -167,7 +168,7 @@ extension ViewController: UICollectionViewDataSource, UICollectionViewDelegateFl
                     return
                 }
                 DispatchQueue.main.async {
-                    if posterPath == pathString {
+                    if cell.posterPath == pathString {
                         cell.imageView?.image = image
                     }
                 }

--- a/movie-app/View/CollectionCell.swift
+++ b/movie-app/View/CollectionCell.swift
@@ -14,9 +14,12 @@ class CollectionCell: UICollectionViewCell {
     @IBOutlet var title: UILabel!
     @IBOutlet var imageView: UIImageView?
     @IBOutlet var ratingView: Rating?
+    var posterPath: String?
 
     override func prepareForReuse() {
+        super.prepareForReuse()
         title.text = ""
+        posterPath = nil
         imageView?.image = nil
         ratingView?.value = 0.0
     }


### PR DESCRIPTION
Previously, when `item.posterPath` was captured as `posterPath`,
it would always be the path of the item irrespective of cell
changes so the comparison in the callback is always true.

This change adds a property to the cell, which is written to
each time the cell is reused, so when the callback happens it
checks the path for the cell's current content.